### PR TITLE
Fix disassembly of `jr` instructions

### DIFF
--- a/mgbdis.py
+++ b/mgbdis.py
@@ -474,10 +474,11 @@ class Bank:
                 else:
                     operand_values.append('@-' + hex_byte(relative_value * -1))
 
+                target_bank = value // 0x4000
+
                 # convert to banked value so it can be used as a label
                 value = rom_address_to_mem_address(value)
 
-                target_bank = value // 0x4000
                 if self.bank_number != target_bank:
                     # don't use labels for relative jumps across banks
                     value = None


### PR DESCRIPTION
The `target_bank` was incorrectly computed, which made the disassembler output data instructions instead of the proper relative jump.

**Before**

```asm
    and  a                                        ; $4148: $a7
    db   $28, $04                                 ; $4149: $28 $04
    xor  a                                        ; $414b: $af
    ldh  [$ffbc], a                               ; $414c: $e0 $bc
    ret                                           ; $414e: $c9

    ld   d, $1d                                   ; $414f: $16 $1d
```

**After**

```asm
    and  a                                        ; $4148: $a7
    jr   z, jr_002_414f                           ; $4149: $28 $04

    xor  a                                        ; $414b: $af
    ldh  [$ffbc], a                               ; $414c: $e0 $bc
    ret                                           ; $414e: $c9

jr_002_414f:
    ld   d, $1d                                   ; $414f: $16 $1d
```