### PR TITLE
Use a portable shebang to find Python 3

### DIFF
--- a/mgbdis.py
+++ b/mgbdis.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 """Disassemble a Game Boy ROM into RGBDS compatible assembly code"""
 


### PR DESCRIPTION
This variant seems to be the recommended and portable way to invoke a Python 3 executable.

It has the added benefit of working even if Python is installed in another location (like it is usually the case when installing python3 on macOS using Homebrew).