### PR TITLE
Resolve symbols in call/jmp targets to bank0

### DIFF
--- a/mgbdis.py
+++ b/mgbdis.py
@@ -200,10 +200,9 @@ class Bank:
         })
 
 
-    def add_label(self, instruction_name, address):
+    def add_target_address(self, instruction_name, address):
         if address not in self.target_addresses[instruction_name]:
             self.target_addresses[instruction_name].add(address)
-
 
 
     def resolve_blocks(self):
@@ -296,7 +295,7 @@ class Bank:
             else:
                 labels.append(label + '::')
         else:
-            # otherwise check generated ones
+            # otherwise, if the address was marked as a target address, generate a label
             for instruction_name in ['call', 'jp', 'jr']:
                 if address in self.target_addresses[instruction_name]:
                     labels.append(self.format_label(instruction_name, address) + ':')
@@ -530,7 +529,7 @@ class Bank:
 
                     if self.first_pass:
                         # add the label
-                        self.add_label(instruction_name, mem_address)
+                        self.add_target_address(instruction_name, mem_address)
                     else:
                         # fetch the label name
                         label = self.get_label_for_jump_target(instruction_name, mem_address)


### PR DESCRIPTION
Currently the code doesn't allow generating labels in bank 0 from other banks.

From what I understand, this is to keep each bank independent on each other. If bank 2 calls to a function in bank 0, for sure the target address could be turned into a function label—but that would make bank 2 compilation dependent on a label defined only in bank 0.

The downside, of course, is that some calls that could be resolved to valid labels are not: the code is sprinkled with `call $3100`, where it is pretty clear that it references a function in bank 0.

I'm not sure about the pros and cons of this—so this PR attempts to improve a bit the situation with a partial solution. **Now when a call/jmp target has a label defined _in the SYM file_** (rather than inferred during the disassembly), **the operand will use this label even if it points to bank 0.**

I feel like this is a good compromise, that could help projects with partial disassemblies without making the banks depend too much on each other.

What do you think?

## Example

**SYM file**

```text
00:3000 SomeFunc
```

**bank 0**
```asm
SomeFunc::  ; a label generated from the SYM file
  call call_000_3100
  ; some code…

call_000_3100:: ; a label inferred from the bank 0 code
   ; some code…
  ret

  ; some unlabeled code at $3110
  ld a, [$FF80]
  ; snip
```

## Before this PR

**bank 1**
```asm
  ; No target address outside of the current bank is ever resolved
  call $3000
  call $3100
  call $3110
```

## With this PR

**bank 1**
```asm
  call SomeFunc ; A target defined in the SYM file is resolved to a label
  call $3100    ; A target pointing to an inferred label in another bank is still not resolved
  call $3110    ; A target is still forbidden to create an inferred label in bank 0
```