### PR TITLE
Add pret style option

### DIFF
--- a/mgbdis.py
+++ b/mgbdis.py
@@ -623,16 +623,15 @@ class Bank:
 
             # add some empty lines after returns and jumps to break up the code blocks
             if instruction_name in ['ret', 'reti', 'jr', 'jp']:
-                if (
+                if not (
                     instruction_name == 'jr' or
                     (instruction_name == 'jp' and len(operand_values) > 1) or
                     (instruction_name == 'ret' and len(operand_values) > 0)
                 ):
-                    # conditional or jr
                     self.append_output('')
-                else:
-                    # always executes
-                    self.append_output('')
+
+                # add an extra new line after any return or jump
+                if not style['pret_style']:
                     self.append_output('')
 
 

--- a/mgbdis.py
+++ b/mgbdis.py
@@ -621,6 +621,18 @@ class Bank:
             instruction_bytes = rom.data[pc:pc + length]
             self.append_output(self.format_instruction(instruction_name, operand_values, pc_mem_address, instruction_bytes))
 
+            # Add a "fallthrough" comment before labels in pret style
+            next_labels = self.get_labels_for_address(pc_mem_address + length)
+            if style['pret_style'] and len(next_labels) > 0:
+
+                # if a new label is after a normal instruction, add comment
+                if not (
+                    instruction_name == 'jr' or
+                    (instruction_name == 'jp' and len(operand_values) == 1) or
+                    (instruction_name == 'ret' and len(operand_values) == 0)
+                ):
+                    self.append_output(';\tfallthrough')
+
             # add some empty lines after returns and jumps to break up the code blocks
             if instruction_name in ['ret', 'reti', 'jr', 'jp']:
                 if not (


### PR DESCRIPTION
I've added a --pret-style arg that changes output a bit to match disassemblies written for [pret](https://github.com/pret). It includes the following:

- All function labels are `Func_[Global Addr]` instead of `[type]_[bank]_[local addr]`
- one newline after conditionless returns and jumps and no newlines otherwise
- `;    fallthrough` comment when a label begins without a conditionless return or jump

I'm not married to `--pret-style` as a name, in fact I quite dislike it. I'm just not creative enough for something else