### PR TITLE
Update reference to array.array.tostring()

### DIFF
--- a/png.py
+++ b/png.py
@@ -194,7 +194,7 @@ def isarray(x):
     return isinstance(x, array)
 
 def tostring(row):
-    return row.tostring()
+    return row.tobytes()
 
 def interleave_planes(ipixels, apixels, ipsize, apsize):
     """


### PR DESCRIPTION
It has been renamed to array.tobytes(): https://docs.python.org/3/library/array.html#array.array.tobytes