### PR TITLE
Escape double quote string

### DIFF
--- a/mgbdis.py
+++ b/mgbdis.py
@@ -675,6 +675,10 @@ class Bank:
 
             byte = rom.data[address]
             if byte >= 0x20 and byte < 0x7F:
+                # escape double-quote character (")
+                if byte == 0x22:
+                    text += '\\'
+
                 text += chr(byte)
             else:
                 if len(text):

--- a/mgbdis.py
+++ b/mgbdis.py
@@ -675,8 +675,8 @@ class Bank:
 
             byte = rom.data[address]
             if byte >= 0x20 and byte < 0x7F:
-                escapeChars = {'"', '\\', '{', '}'}
-                if chr(byte) in escapeChars:
+                
+                if chr(byte) in {'"', '\\', '{', '}'}:
                     text += '\\'
 
                 text += chr(byte)

--- a/mgbdis.py
+++ b/mgbdis.py
@@ -675,8 +675,8 @@ class Bank:
 
             byte = rom.data[address]
             if byte >= 0x20 and byte < 0x7F:
-                # escape double-quote character (")
-                if byte == 0x22:
+                escapeChars = {'"', '\\', '{', '}'}
+                if chr(byte) in escapeChars:
                     text += '\\'
 
                 text += chr(byte)


### PR DESCRIPTION
Currently, string data can be output incorrectly if it contains characters that [rgbasm notes should be escaped](https://rgbds.gbdev.io/docs/v0.6.1/rgbasm.5#String_expressions) (namely `"`, `\`, `{`, `}`). Just made a quick fix 👍

Love the project btw!