### PR TITLE
Allow variable width instead of 16 bytes per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Adding a label for 512 bytes of data:
 0d:4800 .data:200
 ```
 
+Adding a label for 48 bytes of data, 3 bytes per line:
+
+```
+0d:4900 Level_Pointers
+0d:4900 .data:30:3
+```
+
 ### Text
 
 Adding a label for 16 bytes of text:

--- a/mgbdis.py
+++ b/mgbdis.py
@@ -637,7 +637,7 @@ class Bank:
         values = []
         width = 16
 
-        if arguments != None:
+        if arguments is not None:
             width = int(arguments, 16)
 
         for address in range(start_address, end_address):

--- a/mgbdis.py
+++ b/mgbdis.py
@@ -3,7 +3,7 @@
 """Disassemble a Game Boy ROM into RGBDS compatible assembly code"""
 
 __author__ = 'Matt Currie and contributors'
-__credits__ = ['mattcurrie', 'kemenaran', 'bnzis', 'ISSOtm', 'BlueAnthem37510']
+__credits__ = ['mattcurrie', 'kemenaran', 'bnzis', 'ISSOtm', 'BlueAnthem37510', 'brianum']
 __version__ = '3.0'
 __copyright__ = 'Copyright 2018 by Matt Currie'
 __license__ = 'MIT'
@@ -635,6 +635,10 @@ class Bank:
             print('Outputting data in range: {} - {}'.format(hex_word(start_address), hex_word(end_address)))
 
         values = []
+        width = 16
+
+        if arguments != None:
+            width = int(arguments, 16)
 
         for address in range(start_address, end_address):
             mem_address = rom_address_to_mem_address(address)
@@ -650,8 +654,8 @@ class Bank:
 
             values.append(hex_byte(rom.data[address]))
 
-            # output max of 16 bytes per line, and ensure any remaining values are output
-            if len(values) == 16 or (address == end_address - 1 and len(values)):
+            # output max of {width} bytes per line, and ensure any remaining values are output
+            if len(values) == width or (address == end_address - 1 and len(values)):
                 self.append_output(self.format_data(values))
                 values = []
 


### PR DESCRIPTION
This allows to format jump pointers (width: 2) bank/address pointers (width: 3) more readable